### PR TITLE
Add jitpack as package repo

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,6 +28,7 @@ repositories {
     mavenCentral()
     jcenter()
     maven(url = "http://packages.confluent.io/maven/")
+    maven(url = "https://jitpack.io")
     maven(url = "https://repository.mulesoft.org/nexus/content/repositories/public/")
 }
 


### PR DESCRIPTION
Da får vi tak i transitive avhengigheter fra kafka-embedded-env.